### PR TITLE
changed view.proptypes.style to ViewPropTypes.style because of deprecation in React 16

### DIFF
--- a/src/Touchable.js
+++ b/src/Touchable.js
@@ -4,6 +4,7 @@ import {
   View,
   TouchableOpacity,
   TouchableNativeFeedback,
+  ViewPropTypes,
 } from 'react-native';
 import {
   IS_ANDROID,
@@ -40,7 +41,7 @@ const Touchable = ({ onPress, style, children }) => {
 
 Touchable.propTypes = {
   onPress: PropTypes.func.isRequired,
-  style: View.propTypes.style,
+  style: ViewPropTypes.style,
   children: PropTypes.node.isRequired,
 };
 


### PR DESCRIPTION
Don't know if it is backwards compatible with older versions of React / React-Native, but the change is needed for React 16. 