### PR TITLE
fix android crash with actionText 

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ class SnackbarComponent extends Component {
             this.setState({hideDistance: event.nativeEvent.layout.height});
           }}
         >
-          <Text style={[styles.text_msg, {color: this.props.messageColor},this.props.textStyle]}>{this.props.textMessage}</Text>
+          <Text style={[styles.text_msg, {color: this.props.messageColor}]}>{this.props.textMessage}</Text>
           {this.props.actionHandler && !!this.props.actionText &&
             <Touchable onPress={() => {this.props.actionHandler()}} >
               <Text style={[styles.action_text, {color: this.props.accentColor}]}>{this.props.actionText.toUpperCase()}</Text>
@@ -120,7 +120,6 @@ SnackbarComponent.defaultProps = {
   distanceCallback: noop,
   bottom: 0,
   position: "bottom",
-  textStyle:{}
 };
 
 SnackbarComponent.propTypes = {
@@ -130,7 +129,6 @@ SnackbarComponent.propTypes = {
   distanceCallback: PropTypes.func,
   bottom: PropTypes.number,
   position: PropTypes.string, // bottom (default), top
-  textStyle:PropTypes.any
 };
 
 const styles = StyleSheet.create({

--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ class SnackbarComponent extends Component {
           }}
         >
           <Text style={[styles.text_msg, {color: this.props.messageColor}]}>{this.props.textMessage}</Text>
-          {this.props.actionHandler && this.props.actionText &&
+          {this.props.actionHandler && !!this.props.actionText &&
             <Touchable onPress={() => {this.props.actionHandler()}} >
               <Text style={[styles.action_text, {color: this.props.accentColor}]}>{this.props.actionText.toUpperCase()}</Text>
             </Touchable>

--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ class SnackbarComponent extends Component {
             this.setState({hideDistance: event.nativeEvent.layout.height});
           }}
         >
-          <Text style={[styles.text_msg, {color: this.props.messageColor}]}>{this.props.textMessage}</Text>
+          <Text style={[styles.text_msg, {color: this.props.messageColor},this.props.textStyle]}>{this.props.textMessage}</Text>
           {this.props.actionHandler && !!this.props.actionText &&
             <Touchable onPress={() => {this.props.actionHandler()}} >
               <Text style={[styles.action_text, {color: this.props.accentColor}]}>{this.props.actionText.toUpperCase()}</Text>
@@ -120,6 +120,7 @@ SnackbarComponent.defaultProps = {
   distanceCallback: noop,
   bottom: 0,
   position: "bottom",
+  textStyle:{}
 };
 
 SnackbarComponent.propTypes = {
@@ -129,6 +130,7 @@ SnackbarComponent.propTypes = {
   distanceCallback: PropTypes.func,
   bottom: PropTypes.number,
   position: PropTypes.string, // bottom (default), top
+  textStyle:PropTypes.any
 };
 
 const styles = StyleSheet.create({


### PR DESCRIPTION
@SiDevesh With recent React Native versions (0.55.3+), the short-circuit evaluation seems broken in certain cases.
In this lib actionText string is returned instead of the Touchable View on Android Platform.
It will show a problem like this `Cannot Add a child that doesn't have a YogaNode to a parent`