### PR TITLE
fix: handle action text being empty string

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ class SnackbarComponent extends Component {
           <Text style={[styles.text_msg, { color: this.props.messageColor }]}>
             {this.props.textMessage}
           </Text>
-          {this.props.actionHandler && this.props.actionText && (
+          {this.props.actionHandler && Boolean(this.props.actionText) && (
             <Touchable
               onPress={() => {
                 this.props.actionHandler();


### PR DESCRIPTION
Fixes #31 

#28 made this default to an empty string, and since it's just a truthy check, if it's "false" (i.e. empty string) that's returned, and causes RN to crash since there's an empty string outside of a `Text` component