### PR TITLE
Fix actionText is not rendered properly

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,19 +65,17 @@ class SnackbarComponent extends Component {
           <Text style={[styles.text_msg, { color: this.props.messageColor }]}>
             {this.props.textMessage}
           </Text>
-          {this.props.actionHandler && !!this.props.actionText && (
+          {(this.props.actionHandler && !!this.props.actionText) ? (
             <Touchable
               onPress={() => {
                 this.props.actionHandler();
               }}
             >
-              <Text
-                style={[styles.action_text, { color: this.props.accentColor }]}
-              >
+              <Text style={[styles.action_text, { color: this.props.accentColor }]}>
                 {this.props.actionText.toUpperCase()}
               </Text>
             </Touchable>
-          )}
+          ) : null}
         </Animated.View>
       </Animated.View>
     );


### PR DESCRIPTION
Use tri conditional statement to return actionText properly
Previous code raises the following error:
```
Text strings must be rendered within a <Text> component.

Stack trace:
  node_modules/react-native/Libraries/Renderer/implementations/ReactNativeRenderer-dev.js:4137:14 in <anonymous>
  node_modules/react-native/Libraries/Renderer/implementations/ReactNativeRenderer-dev.js:4134:2 in createTextInstance
  node_modules/react-native/Libraries/Renderer/implementations/ReactNativeRenderer-dev.js:15909:12 in completeWork
  node_modules/react-native/Libraries/Renderer/implementations/ReactNativeRenderer-dev.js:19409:28 in completeUnitOfWork
  node_modules/react-native/Libraries/Renderer/implementations/ReactNativeRenderer-dev.js:19380:30 in performUnitOfWork
  node_modules/react-native/Libraries/Renderer/implementations/ReactNativeRenderer-dev.js:19347:39 in workLoopSync
  node_modules/react-native/Libraries/Renderer/implementations/ReactNativeRenderer-dev.js:18997:22 in renderRoot
  [native code]:null in renderRoot
  node_modules/react-native/Libraries/Renderer/implementations/ReactNativeRenderer-dev.js:18709:28 in runRootCallback
  [native code]:null in runRootCallback
  node_modules/react-native/Libraries/Renderer/implementations/ReactNativeRenderer-dev.js:5642:32 in runWithPriority$argument_1
  node_modules/scheduler/cjs/scheduler.development.js:643:23 in unstable_runWithPriority
  node_modules/react-native/Libraries/Renderer/implementations/ReactNativeRenderer-dev.js:5638:22 in flushSyncCallbackQueueImpl
  node_modules/react-native/Libraries/Renderer/implementations/ReactNativeRenderer-dev.js:5627:28 in flushSyncCallbackQueue
  node_modules/react-native/Libraries/Renderer/implementations/ReactNativeRenderer-dev.js:18556:30 in scheduleUpdateOnFiber
  node_modules/react-native/Libraries/Renderer/implementations/ReactNativeRenderer-dev.js:21822:15 in scheduleRootUpdate
  node_modules/react-native/Libraries/Renderer/implementations/ReactNativeRenderer-dev.js:23042:20 in ReactNativeRenderer.render
  node_modules/react-native/Libraries/ReactNative/renderApplication.js:52:52 in renderApplication
  node_modules/react-native/Libraries/ReactNative/AppRegistry.js:116:10 in runnables.appKey.run
  node_modules/react-native/Libraries/ReactNative/AppRegistry.js:197:26 in runApplication
  node_modules/react-native/Libraries/BatchedBridge/MessageQueue.js:436:47 in __callFunction
  node_modules/react-native/Libraries/BatchedBridge/MessageQueue.js:111:26 in __guard$argument_0
  node_modules/react-native/Libraries/BatchedBridge/MessageQueue.js:384:10 in __guard
  node_modules/react-native/Libraries/BatchedBridge/MessageQueue.js:110:17 in __guard$argument_0
  [native code]:null in callFunctionReturnFlushedQueue
  ...
```

Tested on Expo Sdk 36(React Native 0.61)