### PR TITLE
"`useNativeDriver` was not specified" error fixed.

### DIFF
--- a/index.js
+++ b/index.js
@@ -113,6 +113,7 @@ class SnackbarComponent extends Component {
         duration: durationValues.entry,
         toValue: 1,
         easing: easingValues.entry,
+        useNativeDriver: false
       }).start();
       if (nextProps.autoHidingTime) {
         const hideFunc = this.hideSnackbar.bind(this);
@@ -149,6 +150,7 @@ class SnackbarComponent extends Component {
       duration: durationValues.exit,
       toValue: 0,
       easing: easingValues.exit,
+      useNativeDriver: false
     }).start();
   }
 }


### PR DESCRIPTION
Fixed this error: "SnackBar" Animated: `useNativeDriver` was not specified. This is a required option and must be explicitly set to `true` or `false`